### PR TITLE
Add global bones_compat option

### DIFF
--- a/autoload/bones.vim
+++ b/autoload/bones.vim
@@ -1,0 +1,9 @@
+function! bones#_compat(colors_name)
+    if exists('g:' . a:colors_name . '_compat')
+        return g:{a:colors_name}_compat != 0
+    elseif exists('g:bones_compat')
+        return g:bones_compat != 0
+    else
+        return 0
+    endif
+endfunction

--- a/colors/duckbones.vim
+++ b/colors/duckbones.vim
@@ -5,7 +5,7 @@ endif
 let g:colors_name = 'duckbones'
 set background=dark
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/forestbones.vim
+++ b/colors/forestbones.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'forestbones'
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim' && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/kanagawabones.vim
+++ b/colors/kanagawabones.vim
@@ -5,7 +5,7 @@ endif
 let g:colors_name = 'kanagawabones'
 set background=dark
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/neobones.vim
+++ b/colors/neobones.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'neobones'
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/nordbones.vim
+++ b/colors/nordbones.vim
@@ -5,7 +5,7 @@ endif
 let g:colors_name = 'nordbones'
 set background=dark
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/rosebones.vim
+++ b/colors/rosebones.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'rosebones'
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/seoulbones.vim
+++ b/colors/seoulbones.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'seoulbones'
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/tokyobones.vim
+++ b/colors/tokyobones.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'tokyobones'
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/vimbones.vim
+++ b/colors/vimbones.vim
@@ -5,7 +5,7 @@ endif
 let g:colors_name = 'vimbones'
 set background=light
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/zenbones.vim
+++ b/colors/zenbones.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'zenbones'
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/zenburned.vim
+++ b/colors/zenburned.vim
@@ -5,7 +5,7 @@ endif
 let g:colors_name = 'zenburned'
 set background=dark
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/colors/zenwritten.vim
+++ b/colors/zenwritten.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'zenwritten'
 
-if has('nvim') && (!exists('g:' . g:colors_name . '_compat') || g:{g:colors_name}_compat == 0)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif

--- a/doc/zenbones.md
+++ b/doc/zenbones.md
@@ -85,9 +85,11 @@ the flavor name e.g. `g:rosebones_italic_comments`.
 | colorize_diagnostic_underline_text | both       | `false` | Colorize the fg of `DiagnosticUnderline*`.                                |
 | transparent_background             | both       | `false` | Make background transparent.                                              |
 
-#### g:zenbones_compat
+#### g:bones_compat
 
-Set to `1` to enable compatibility mode. Enabled in Vim.
+Set to `1` to enable compatibility mode for all colorschemes. Enabled in Vim. To
+enable/disable compatibility mode for a specific theme, set the variable
+`g:{theme}_compat` to `0` or `1`, e.g. `let g:zenbones_compat = 1`.
 
 ### lightline
 


### PR DESCRIPTION
This way you don't have to specify an `_compat` option for every color scheme if you don't want to install Lush, and you don't need to update your init.vim/.vimrc if/when new themes are added.

The compat option for a specific theme takes priority; if you have `let g:rosebones_compat = 0` and `let g:bones_compat = 1`, rosebones will _not_ run in compat mode. Compatibility mode is disabled by default like before.

This is backward-compatible as far as I can tell, other than using a new global variable.