### PR TITLE
fix: unmatched parenthesis

### DIFF
--- a/colors/forestbones.vim
+++ b/colors/forestbones.vim
@@ -4,7 +4,7 @@ endif
 
 let g:colors_name = 'forestbones'
 
-if has('nvim' && !bones#_compat(g:colors_name)
+if has('nvim') && !bones#_compat(g:colors_name)
     lua require("zenbones.util").apply_colorscheme()
     finish
 endif


### PR DESCRIPTION
When forestbones is sourced, neovim throws:

"E116: Invalid arguments for function has"

This bug was introduced by a typo in commit [6612373](https://github.com/mcchrish/zenbones.nvim/commit/661237348a9e5b6e2243cd82f4c01d51fd083895). forestbones is the only color scheme affected by the typo.