### PR TITLE
feat(main): support nvim-notify

### DIFF
--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -438,6 +438,17 @@ local function generate(p, opt)
 
 			FlashLabel                       { bg = p.water.lightness(p1.bg.l + 24), fg = p.fg },
 			FlashBackdrop                    { fg = Comment.fg },
+
+			NotifyERRORIcon                  { DiagnosticError },
+			NotifyERRORTitle                 { DiagnosticError },
+			NotifyWARNIcon                   { DiagnosticWarn },
+			NotifyWARNTitle                  { DiagnosticWarn },
+			NotifyINFOIcon                   { DiagnosticInfo },
+			NotifyINFOTitle                  { DiagnosticInfo },
+			NotifyDEBUGIcon                  { DiagnosticHint },
+			NotifyDEBUGTitle                 { DiagnosticHint },
+			NotifyTRACEIcon                  { DiagnosticHint },
+			NotifyTRACETitle                 { DiagnosticHint },
 		}
 	end)
 	-- stylua: ignore end

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -438,6 +438,17 @@ local function generate(p, opt)
 
 			FlashLabel                       { bg = p.water.lightness(p1.bg.l - 15), fg = p.fg },
 			FlashBackdrop                    { fg = Comment.fg },
+
+			NotifyERRORIcon                  { DiagnosticError },
+			NotifyERRORTitle                 { DiagnosticError },
+			NotifyWARNIcon                   { DiagnosticWarn },
+			NotifyWARNTitle                  { DiagnosticWarn },
+			NotifyINFOIcon                   { DiagnosticInfo },
+			NotifyINFOTitle                  { DiagnosticInfo },
+			NotifyDEBUGIcon                  { DiagnosticHint },
+			NotifyDEBUGTitle                 { DiagnosticHint },
+			NotifyTRACEIcon                  { DiagnosticHint },
+			NotifyTRACETitle                 { DiagnosticHint },
 		}
 	end)
 	-- stylua: ignore end


### PR DESCRIPTION
Add support for nvim-notify plugin.

The plugin also provides highlight groups for the border color of the popups in addition to the title and icon colors. However, in the spirit of zenbones using color conservatively, I decided not to set the border color a shade of the diagnost color.

Before changes:
<img width="1141" alt="image" src="https://github.com/mcchrish/zenbones.nvim/assets/747855/75813fff-70e2-4fe5-a2ff-5ed5ac83d0ab">

After changes:
<img width="1141" alt="image" src="https://github.com/mcchrish/zenbones.nvim/assets/747855/55491f8e-875e-49ac-b57a-221b3b39be08">
