### PR TITLE
feat: add colors for blink.cmp label matches

### DIFF
--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -496,10 +496,13 @@ local function generate(p, opt)
 			CmpItemKind                      { fg = p1.fg4 },
 			CmpItemMenu                      { fg = p1.fg5 },
 
-			BlinkCmpLabelDetail              { Type },
-			BlinkCmpLabelDescription         { Type },
-			BlinkCmpSource                   { Type },
+			BlinkCmpLabel                    { fg = p1.fg2 },
+			BlinkCmpLabelDeprecated          { fg = p1.fg6 },
+			BlinkCmpLabelMatch               { fg = p.fg, gui = "bold" },
+			BlinkCmpLabelDetail              { fg = p1.fg4 },
+			BlinkCmpLabelDescription         { fg = p1.fg4 },
 			BlinkCmpKind                     { fg = p1.fg4 },
+			BlinkCmpSource                   { fg = p1.fg4 },
 
 			NnnNormal                        { NvimTreeNormal },
 			NnnNormalNC                      { NnnNormal },

--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -496,6 +496,7 @@ local function generate(p, opt)
 			CmpItemKind                      { fg = p1.fg4 },
 			CmpItemMenu                      { fg = p1.fg5 },
 
+			BlinkCmpLabelMatch               { fg = p.blossom, gui = "bold" },
 			BlinkCmpLabelDetail              { Type },
 			BlinkCmpLabelDescription         { Type },
 			BlinkCmpSource                   { Type },

--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -496,13 +496,10 @@ local function generate(p, opt)
 			CmpItemKind                      { fg = p1.fg4 },
 			CmpItemMenu                      { fg = p1.fg5 },
 
-			BlinkCmpLabel                    { fg = p1.fg2 },
-			BlinkCmpLabelDeprecated          { fg = p1.fg6 },
-			BlinkCmpLabelMatch               { fg = p.fg, gui = "bold" },
-			BlinkCmpLabelDetail              { fg = p1.fg4 },
-			BlinkCmpLabelDescription         { fg = p1.fg4 },
+			BlinkCmpLabelDetail              { Type },
+			BlinkCmpLabelDescription         { Type },
+			BlinkCmpSource                   { Type },
 			BlinkCmpKind                     { fg = p1.fg4 },
-			BlinkCmpSource                   { fg = p1.fg4 },
 
 			NnnNormal                        { NvimTreeNormal },
 			NnnNormalNC                      { NnnNormal },

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -496,10 +496,13 @@ local function generate(p, opt)
 			CmpItemKind                      { fg = p1.fg4 },
 			CmpItemMenu                      { fg = p1.fg5 },
 
-			BlinkCmpLabelDetail              { Type },
-			BlinkCmpLabelDescription         { Type },
-			BlinkCmpSource                   { Type },
+			BlinkCmpLabel                    { fg = p1.fg2 },
+			BlinkCmpLabelDeprecated          { fg = p1.fg6 },
+			BlinkCmpLabelMatch               { fg = p.fg, gui = "bold" },
+			BlinkCmpLabelDetail              { fg = p1.fg4 },
+			BlinkCmpLabelDescription         { fg = p1.fg4 },
 			BlinkCmpKind                     { fg = p1.fg4 },
+			BlinkCmpSource                   { fg = p1.fg4 },
 
 			NnnNormal                        { NvimTreeNormal },
 			NnnNormalNC                      { NnnNormal },

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -496,6 +496,7 @@ local function generate(p, opt)
 			CmpItemKind                      { fg = p1.fg4 },
 			CmpItemMenu                      { fg = p1.fg5 },
 
+			BlinkCmpLabelMatch               { fg = p.blossom, gui = "bold" },
 			BlinkCmpLabelDetail              { Type },
 			BlinkCmpLabelDescription         { Type },
 			BlinkCmpSource                   { Type },

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -496,13 +496,10 @@ local function generate(p, opt)
 			CmpItemKind                      { fg = p1.fg4 },
 			CmpItemMenu                      { fg = p1.fg5 },
 
-			BlinkCmpLabel                    { fg = p1.fg2 },
-			BlinkCmpLabelDeprecated          { fg = p1.fg6 },
-			BlinkCmpLabelMatch               { fg = p.fg, gui = "bold" },
-			BlinkCmpLabelDetail              { fg = p1.fg4 },
-			BlinkCmpLabelDescription         { fg = p1.fg4 },
+			BlinkCmpLabelDetail              { Type },
+			BlinkCmpLabelDescription         { Type },
+			BlinkCmpSource                   { Type },
 			BlinkCmpKind                     { fg = p1.fg4 },
-			BlinkCmpSource                   { fg = p1.fg4 },
 
 			NnnNormal                        { NvimTreeNormal },
 			NnnNormalNC                      { NnnNormal },


### PR DESCRIPTION
Problem: `cmp` and `blink.cmp` are configured with different completion menu colors, when they should be (relatively) similar (for standardization/convention purposes).

Solution: Update `blink.cmp` colors to match those of `cmp`. Also added a color for `BlinkCmpLabelMatch`, the highlight for matched portions of completion items.