### PR TITLE
feat: support `mini.icons`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ currently supported.
 - [NvimTree](https://github.com/kyazdani42/nvim-tree.lua)
 - [n³](https://github.com/mcchrish/nnn.vim)
 - [Mason](https://github.com/williamboman/mason.nvim)
+- [mini.icons](https://github.com/nvim-mini/mini.nvim/blob/main/readmes/mini-icons.md)
 
 ## Other implementations
 

--- a/lua/zenbones/shipwright/runners/vim.lua
+++ b/lua/zenbones/shipwright/runners/vim.lua
@@ -50,6 +50,7 @@ run(
 				or string.match(color, "NvimTree")
 				or string.match(color, "Cmp")
 				or string.match(color, "Mason")
+				or string.match(color, "Mini")
 			)
 		end, colors)
 		return {

--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -541,6 +541,16 @@ local function generate(p, opt)
 			NotifyTRACEIcon                  { DiagnosticHint },
 			NotifyTRACETitle                 { DiagnosticHint },
 
+			MiniIconsAzure                   { fg = p.water },
+			MiniIconsCyan                    { fg = p.sky },
+			MiniIconsPurple                  { fg = p.blossom },
+			MiniIconsBlue                    { fg = p.sky1 },
+			MiniIconsGreen                   { fg = p.leaf },
+			MiniIconsGrey                    { fg = p1.fg4 },
+			MiniIconsOrange                  { fg = p.wood },
+			MiniIconsRed                     { fg = p.rose },
+			MiniIconsYellow                  { fg = p.wood1 },
+
 			RenderMarkdownCode { bg = LspInlayHint.bg },
 		}
 	end)

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -541,6 +541,16 @@ local function generate(p, opt)
 			NotifyTRACEIcon                  { DiagnosticHint },
 			NotifyTRACETitle                 { DiagnosticHint },
 
+			MiniIconsAzure                   { fg = p.water },
+			MiniIconsCyan                    { fg = p.sky },
+			MiniIconsPurple                  { fg = p.blossom },
+			MiniIconsBlue                    { fg = p.sky1 },
+			MiniIconsGreen                   { fg = p.leaf },
+			MiniIconsGrey                    { fg = p1.fg4 },
+			MiniIconsOrange                  { fg = p.wood1 },
+			MiniIconsRed                     { fg = p.rose },
+			MiniIconsYellow                  { fg = p.wood },
+
 			RenderMarkdownCode { bg = LspInlayHint.bg },
 		}
 	end)


### PR DESCRIPTION
Preview, dark:
<img width="607" height="262" alt="image" src="https://github.com/user-attachments/assets/5876ce75-6f54-4deb-9d64-f978f31a3805" />

Light:
<img width="618" height="260" alt="image" src="https://github.com/user-attachments/assets/998e1bf6-3348-4c14-a4ba-c4a321ff9f33" />

Not sure if I've got the ideal colors, suggestions are welcome.