### PR TITLE
fix: link `@lsp.type.variable` to `@variable`

### DIFF
--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -347,7 +347,7 @@ local function generate(p, opt)
 			sym "@lsp.type.string"                        { sym "@string" },
 			sym "@lsp.type.typeAlias"                     { sym "@type.definition" },
 			sym "@lsp.type.unresolvedReference"           { gui = "undercurl", sp = Error.fg },
-			sym "@lsp.type.variable"                      { },
+			sym "@lsp.type.variable"                      { sym "@variable" },
 			sym "@lsp.typemod.class.defaultLibrary"       { sym "@type.builtin" },
 			sym "@lsp.typemod.enum.defaultLibrary"        { sym "@type.builtin" },
 			sym "@lsp.typemod.enumMember.defaultLibrary"  { sym "@constant.builtin" },

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -347,7 +347,7 @@ local function generate(p, opt)
 			sym "@lsp.type.string"                        { sym "@string" },
 			sym "@lsp.type.typeAlias"                     { sym "@type.definition" },
 			sym "@lsp.type.unresolvedReference"           { gui = "undercurl", sp = Error.fg },
-			sym "@lsp.type.variable"                      { },
+			sym "@lsp.type.variable"                      { sym "@variable" },
 			sym "@lsp.typemod.class.defaultLibrary"       { sym "@type.builtin" },
 			sym "@lsp.typemod.enum.defaultLibrary"        { sym "@type.builtin" },
 			sym "@lsp.typemod.enumMember.defaultLibrary"  { sym "@constant.builtin" },


### PR DESCRIPTION
I'm not sure if it was intentional but the highlight of `@lsp.type.variable` was cleared. This doesn't make too much difference with tree-sitter enabled except when the variable is inside a format string:

<img width="1137" height="132" alt="image" src="https://github.com/user-attachments/assets/e08a28a7-e350-4b92-a0bc-a63a839c30f8" />

This PR fixes the issue by linking it to `@variable` again:

<img width="1137" height="132" alt="image" src="https://github.com/user-attachments/assets/636bca48-3836-4f9b-ab8e-0763a1661546" />