### PR TITLE
feat: set additional diff highlights

### DIFF
--- a/lua/zenbones/specs/dark.lua
+++ b/lua/zenbones/specs/dark.lua
@@ -376,6 +376,10 @@ local function generate(p, opt)
 			diffLine                  { fg = p.blossom, gui = "bold" },
 			diffIndexLine             { fg = p.wood },
 
+			Added                     { fg = p.leaf },
+			Removed                   { fg = p.rose },
+			Changed                   { fg = p.water },
+
 			gitcommitOverflow         { WarningMsg },
 
 			markdownUrl               { SpecialComment },

--- a/lua/zenbones/specs/light.lua
+++ b/lua/zenbones/specs/light.lua
@@ -376,6 +376,10 @@ local function generate(p, opt)
 			diffLine                  { fg = p.blossom, gui = "bold" },
 			diffIndexLine             { fg = p.wood },
 
+			Added                     { fg = p.leaf },
+			Removed                   { fg = p.rose },
+			Changed                   { fg = p.water },
+
 			gitcommitOverflow         { WarningMsg },
 
 			markdownUrl               { SpecialComment },


### PR DESCRIPTION
Sets the built-in `Added`, `Removed` and `Changed` diff highlights which are currently unset and not linked to anything. They are also used by some plugins, e.g. `mini.diff`